### PR TITLE
Allow to read/write git information in a deploy.

### DIFF
--- a/deploys_test.go
+++ b/deploys_test.go
@@ -79,7 +79,7 @@ func TestDeploysService_Create(t *testing.T) {
 		testMethod(t, r, "POST")
 
 		r.ParseForm()
-		if _,ok := r.Form["draft"]; ok {
+		if _, ok := r.Form["draft"]; ok {
 			t.Errorf("Draft should not be a query parameter for a normal deploy")
 		}
 
@@ -169,7 +169,7 @@ func TestDeploysService_Create_Zip(t *testing.T) {
 	mux.HandleFunc("/api/v1/sites/my-site/deploys", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		r.ParseForm()
-		if _,ok := r.Form["draft"]; ok {
+		if _, ok := r.Form["draft"]; ok {
 			t.Errorf("Draft should not be a query parameter for a normal deploy")
 		}
 
@@ -200,7 +200,6 @@ func TestDeploysService_Create_Zip(t *testing.T) {
 	}
 }
 
-
 func TestDeploysService_CreateDraft_Zip(t *testing.T) {
 	setup()
 	defer teardown()
@@ -208,7 +207,7 @@ func TestDeploysService_CreateDraft_Zip(t *testing.T) {
 	mux.HandleFunc("/api/v1/sites/my-site/deploys", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		r.ParseForm()
-		if val,ok := r.Form["draft"]; ok == false || val[0] != "true" {
+		if val, ok := r.Form["draft"]; ok == false || val[0] != "true" {
 			t.Errorf("Draft should be a true parameter for a draft deploy")
 		}
 		fmt.Fprint(w, `{"id":"my-deploy"})`)


### PR DESCRIPTION
This information is not updated if the deploy already exists
and has it present. It's only updated when the existent deploy misses
that data.

Signed-off-by: David Calavera <david.calavera@gmail.com>