### PR TITLE
Fix issue with error messages when a file upload fails

### DIFF
--- a/deploys.go
+++ b/deploys.go
@@ -330,7 +330,9 @@ func (deploy *Deploy) DeployDirWithGitInfo(dir, branch, commitRef string) (*Resp
 				err := backoff.Retry(func() error { return deploy.uploadFile(dir, path, sharedErr) }, b)
 				if err != nil {
 					sharedErr.mutex.Lock()
-					sharedErr.err = err
+					if sharedErr.err == nil {
+						sharedErr.err = err
+					}
 					sharedErr.mutex.Unlock()
 					<-sem
 					wg.Done()


### PR DESCRIPTION
When one file being uploaded failed, we'll cancel other uploads to stop the deploy straight away.
However, we were overriding the original error message with a generic error saying:
    Canceled because upload has already failed
This makes sure we don't overwrite the shared error message