### PR TITLE
Update logging

### DIFF
--- a/deploys.go
+++ b/deploys.go
@@ -42,8 +42,8 @@ type Deploy struct {
 	CreatedAt Timestamp `json:"created_at"`
 	UpdatedAt Timestamp `json:"updated_at"`
 
-	Branch    string `json:"branch"`
-	CommitRef string `json:"commit_ref"`
+	Branch    string `json:"branch,omitempty"`
+	CommitRef string `json:"commit_ref,omitempty"`
 
 	client *Client
 	logger *logrus.Entry
@@ -92,8 +92,8 @@ func (u *uploadError) Get() error {
 type deployFiles struct {
 	Files     *map[string]string `json:"files"`
 	Async     bool               `json:"async"`
-	Branch    string             `json:"branch"`
-	CommitRef string             `json:"commit_ref"`
+	Branch    string             `json:"branch,omitempty"`
+	CommitRef string             `json:"commit_ref,omitempty"`
 }
 
 func (s *DeploysService) apiPath() string {
@@ -111,7 +111,7 @@ func (s *DeploysService) Create(dirOrZip string) (*Deploy, *Response, error) {
 	return s.create(dirOrZip, false)
 }
 
-// Create a new draft deploy. Draft deploys will be uploaded and processed, but
+// CreateDraft a new draft deploy. Draft deploys will be uploaded and processed, but
 // won't affect the active deploy for a site.
 func (s *DeploysService) CreateDraft(dirOrZip string) (*Deploy, *Response, error) {
 	return s.create(dirOrZip, true)

--- a/deploys.go
+++ b/deploys.go
@@ -86,7 +86,7 @@ func (u *uploadError) Set(err error) {
 func (u *uploadError) Get() error {
 	u.mutex.Lock()
 	defer u.mutex.Unlock()
-	return err
+	return u.err
 }
 
 type deployFiles struct {

--- a/deploys.go
+++ b/deploys.go
@@ -99,9 +99,8 @@ type deployFiles struct {
 func (s *DeploysService) apiPath() string {
 	if s.site != nil {
 		return path.Join(s.site.apiPath(), "deploys")
-	} else {
-		return "/deploys"
 	}
+	return "/deploys"
 }
 
 // Create a new deploy
@@ -263,6 +262,7 @@ func (deploy *Deploy) DeployDirWithGitInfo(dir, branch, commitRef string) (*Resp
 	})
 	defer log.Infof("Finished deploying directory %s", dir)
 
+	log.Infof("Starting deploy of directory %s", dir)
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -351,7 +351,7 @@ func (deploy *Deploy) DeployDirWithGitInfo(dir, branch, commitRef string) (*Resp
 		lookup[sha] = true
 	}
 
-	log.Debugf("Going to deploy the %d required files", len(lookup))
+	log.Infof("Going to deploy the %d required files", len(lookup))
 
 	// Use a channel as a semaphore to limit # of parallel uploads
 	sem := make(chan int, deploy.client.MaxConcurrentUploads)
@@ -399,6 +399,7 @@ func (deploy *Deploy) deployZip(zip string) (*Response, error) {
 		"function": "zip",
 		"zip_path": zip,
 	})
+	log.Infof("Starting to deploy zip file %s", zip)
 	zipPath, err := filepath.Abs(zip)
 	if err != nil {
 		return nil, err
@@ -412,10 +413,15 @@ func (deploy *Deploy) deployZip(zip string) (*Response, error) {
 	defer zipFile.Close()
 
 	info, err := zipFile.Stat()
-
 	if err != nil {
 		return nil, err
 	}
+
+	log.WithFields(logrus.Fields{
+		"name": info.Name(),
+		"size": info.Size(),
+		"mode": info.Mode(),
+	}).Debugf("Opened file %s of %s bytes", info.Name(), info.Size())
 
 	options := &RequestOptions{
 		RawBody:       zipFile,
@@ -429,7 +435,7 @@ func (deploy *Deploy) deployZip(zip string) (*Response, error) {
 		log.WithError(err).Warn("Error while uploading zip file")
 	}
 
-	log.Debug("Finished uploading zip file")
+	log.Info("Finished uploading zip file")
 	return resp, err
 }
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,28 +1,34 @@
-hash: 38ed1bba7fd57cade148a119117ebf01db5fa66f834e033c490cc1b5e77362dc
-updated: 2016-06-28T14:33:22.402741954-07:00
+hash: d326f49a14f016e4a588de5d3fda573468d983e8c541e66286499c7855134435
+updated: 2016-08-31T21:33:07.707202933-07:00
 imports:
 - name: github.com/cenkalti/backoff
   version: cdf48bbc1eb78d1349cbda326a4a037f7ba565c6
 - name: github.com/golang/protobuf
-  version: 78b168c14fc28c8c711844d210f7ab845083e3b1
+  version: 1f49d83d9aa00e6ce4fc8258c71cc7786aec968a
   subpackages:
   - proto
+- name: github.com/Sirupsen/logrus
+  version: 4b6ea7319e214d98c938f12692336f7ca9348d6b
 - name: golang.org/x/net
-  version: 04557861f124410b768b1ba5bb3a91b705afbfc6
+  version: 9bc2a3340c92c17a20edcd0080e93851ed58f5d5
   subpackages:
   - context
 - name: golang.org/x/oauth2
-  version: 65a8d08c6292395d47053be10b3c5e91960def76
+  version: 4d549c893be7d4011bab739cc585d091a7188d27
   subpackages:
   - internal
+- name: golang.org/x/sys
+  version: a646d33e2ee3172a661fc09bca23bb4889a41bc8
+  subpackages:
+  - unix
 - name: google.golang.org/appengine
-  version: 267c27e7492265b84fc6719503b14a1e17975d79
+  version: 4f7eeb5305a4ba1966344836ba4af9996b7b4e05
   subpackages:
-  - urlfetch
   - internal
-  - internal/urlfetch
   - internal/base
   - internal/datastore
   - internal/log
   - internal/remote_api
-devImports: []
+  - internal/urlfetch
+  - urlfetch
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,3 +2,5 @@ package: github.com/netlify/netlify-go
 import:
 - package: github.com/cenkalti/backoff
 - package: golang.org/x/oauth2
+- package: github.com/Sirupsen/logrus
+  version: v0.10.0

--- a/netlify.go
+++ b/netlify.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 
@@ -38,7 +39,8 @@ type Config struct {
 	BaseUrl   string
 	UserAgent string
 
-	HttpClient *http.Client
+	HttpClient     *http.Client
+	RequestTimeout time.Duration
 
 	MaxConcurrentUploads int
 }
@@ -126,6 +128,9 @@ func NewClient(config *Config) *Client {
 		client.client = config.HttpClient
 	} else if config.AccessToken != "" {
 		client.client = oauth.NewClient(oauth.NoContext, config)
+		if config.RequestTimeout > 0 {
+			client.client.Timeout = config.RequestTimeout
+		}
 	}
 
 	if &config.UserAgent != nil {

--- a/netlify.go
+++ b/netlify.go
@@ -91,6 +91,10 @@ type ErrorResponse struct {
 	Message  string
 }
 
+func (r *ErrorResponse) Error() string {
+	return r.Message
+}
+
 // All List methods takes a ListOptions object controlling pagination
 type ListOptions struct {
 	Page    int
@@ -108,10 +112,6 @@ func (o *ListOptions) toQueryParamsMap() *url.Values {
 		}
 	}
 	return &params
-}
-
-func (r *ErrorResponse) Error() string {
-	return r.Message
 }
 
 // NewClient returns a new netlify API client

--- a/netlify.go
+++ b/netlify.go
@@ -40,8 +40,6 @@ type Config struct {
 
 	HttpClient *http.Client
 
-	LogLevel logrus.Level
-
 	MaxConcurrentUploads int
 }
 
@@ -52,7 +50,7 @@ func (c *Config) Token() (*oauth.Token, error) {
 // The netlify Client
 type Client struct {
 	client *http.Client
-	log    *logrus.Entry
+	log    *logrus.Logger
 
 	BaseUrl   *url.URL
 	UserAgent string
@@ -142,12 +140,7 @@ func NewClient(config *Config) *Client {
 		client.MaxConcurrentUploads = DefaultMaxConcurrentUploads
 	}
 
-	logrus.SetLevel(config.LogLevel)
-	logrus.SetFormatter(&logrus.TextFormatter{
-		FullTimestamp:    true,
-		DisableTimestamp: false,
-	})
-
+	logrus.SetOutput(ioutil.Discard)
 	client.log = logrus.StandardLogger()
 	client.Sites = &SitesService{client: client}
 	client.Deploys = &DeploysService{client: client}
@@ -161,15 +154,7 @@ func NewClient(config *Config) *Client {
 	return client
 }
 
-func (c *Client) SetLogLevel(level uint8) error {
-	lvl, err := logrus.ParseLevel(level)
-	if err != nil {
-		return err
-	}
-	logrus.SetLevel(lvl)
-}
-
-func (c *Client) SetLogger(log *logrus.Entry) {
+func (c *Client) SetLogger(log *logrus.Logger) {
 	if log != nil {
 		c.log = logrus.StandardLogger()
 	}

--- a/netlify.go
+++ b/netlify.go
@@ -52,7 +52,7 @@ func (c *Config) Token() (*oauth.Token, error) {
 // The netlify Client
 type Client struct {
 	client *http.Client
-	log    *logrus.Logger
+	log    *logrus.Entry
 
 	BaseUrl   *url.URL
 	UserAgent string
@@ -146,7 +146,8 @@ func NewClient(config *Config) *Client {
 	}
 
 	logrus.SetOutput(ioutil.Discard)
-	client.log = logrus.StandardLogger()
+	client.log = logrus.NewEntry(logrus.StandardLogger())
+
 	client.Sites = &SitesService{client: client}
 	client.Deploys = &DeploysService{client: client}
 
@@ -159,9 +160,9 @@ func NewClient(config *Config) *Client {
 	return client
 }
 
-func (c *Client) SetLogger(log *logrus.Logger) {
+func (c *Client) SetLogger(log *logrus.Entry) {
 	if log != nil {
-		c.log = logrus.StandardLogger()
+		c.log = logrus.NewEntry(logrus.StandardLogger())
 	}
 	c.log = log
 }

--- a/netlify.go
+++ b/netlify.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Sirupsen/logrus"
+
 	oauth "golang.org/x/oauth2"
 )
 
@@ -38,6 +40,8 @@ type Config struct {
 
 	HttpClient *http.Client
 
+	LogLevel logrus.Level
+
 	MaxConcurrentUploads int
 }
 
@@ -48,6 +52,7 @@ func (c *Config) Token() (*oauth.Token, error) {
 // The netlify Client
 type Client struct {
 	client *http.Client
+	log    *logrus.Entry
 
 	BaseUrl   *url.URL
 	UserAgent string
@@ -137,10 +142,38 @@ func NewClient(config *Config) *Client {
 		client.MaxConcurrentUploads = DefaultMaxConcurrentUploads
 	}
 
+	logrus.SetLevel(config.LogLevel)
+	logrus.SetFormatter(&logrus.TextFormatter{
+		FullTimestamp:    true,
+		DisableTimestamp: false,
+	})
+
+	client.log = logrus.StandardLogger()
 	client.Sites = &SitesService{client: client}
 	client.Deploys = &DeploysService{client: client}
 
+	client.log.WithFields(logrus.Fields{
+		"base_url":               client.BaseUrl.String(),
+		"user_agent":             client.UserAgent,
+		"max_concurrent_uploads": client.MaxConcurrentUploads,
+	}).Debug("created client")
+
 	return client
+}
+
+func (c *Client) SetLogLevel(level uint8) error {
+	lvl, err := logrus.ParseLevel(level)
+	if err != nil {
+		return err
+	}
+	logrus.SetLevel(lvl)
+}
+
+func (c *Client) SetLogger(log *logrus.Entry) {
+	if log != nil {
+		c.log = logrus.StandardLogger()
+	}
+	c.log = log
 }
 
 func (c *Client) newRequest(method, apiPath string, options *RequestOptions) (*http.Request, error) {


### PR DESCRIPTION
Adds a logging hook. It will let us do better in buildbot. 

Also - in reviewing this I suspect that there is something around the buildbot doing async uploads. 
Hopefully it will give us insight into: 
problem 1: running another build when the deploy isn't completed. If the deploy goes into async mode, it will unblock that call causing the second build to get triggered. 

problem 2: "hung build" - if the deploy goes into async it could mean that the build gets acknowledged (closing it) but the deploy completes. Could this cause an issue around the deploy not getting closed/auto-deploying?